### PR TITLE
New Optional Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Although this feature will allow you to finely control which service sees which 
 ### Using [Jinja2](http://jinja.pocoo.org/) in `docker-compose.yml` file 
 *New from version 0.4.0*
 
-To support the relatively common use case of wanting to launch as many compute containers (with the same configuration) as the number of GPUs avaialble on the target machine, `nvidia-docker-compose` now supports use of [Jinja2](http://jinja.pocoo.org/) in the `docker-compose.yml.jinja` file. Combined with the ability to specify GPU targeting, you can now write `docker-compose` config that adapts flexibility to the GPU availability. For an example if you prepare `docker-compose.yml.jinja` (note the `.jinja` suffix):
+To support the relatively common use case of wanting to launch as many compute containers (with the same configuration) as the number of GPUs available on the target machine, `nvidia-docker-compose` now supports use of [Jinja2](http://jinja.pocoo.org/). Combined with the ability to specify GPU targeting, you can now write `docker-compose` config that adapts flexibility to the GPU availability. For an example if you prepare the following template and save it as `docker-compose.yml.jinja`:
 
 ```yaml
 version: "2"
@@ -76,7 +76,7 @@ services:
   {% endfor %}
 ```
 
-and run `nvidia-docker-compose`, it will automatically pick up the Jinja template, process it and expand it to the following `docker-compose.yml`:
+and run `nvidia-docker-compose --template docker-compose.yml.jinja`, it will pick up the Jinja template, process it and expand it to the following `docker-compose.yml`:
 
 ```yaml
 version: "2"
@@ -107,6 +107,14 @@ services:
       - ./notebooks:/notebooks
 ```
 on a 3 GPU machine. The Jinja variable `N_GPU` automatically reflects the available number of the GPUs on the system. This `docker-compose.yml` is then processed by `nvidia-docker-compose` just like any other config file to launch GPU enabled containers.
+
+### Generating Compose File Only
+
+If you want to generate GPU-enabled compose file for later use, -G/--generate flag will make nvidia-docker-compose exit after generating the compose file without running docker-compose.
+
+```bash
+$ nvidia-docker-compose -G ...
+```
 
 ## How it works
 `nvidia-docker-compose` is a simple Python script that performs two actions:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ services:
   {% endfor %}
 ```
 
-and run `nvidia-docker-compose --template docker-compose.yml.jinja`, it will pick up the Jinja template, process it and expand it to the following `docker-compose.yml`:
+and run:
+
+```bash
+$ nvidia-docker-compose --template docker-compose.yml.jinja ...
+```
+
+It will pick up the Jinja template, process it and expand it to the following `docker-compose.yml`:
 
 ```yaml
 version: "2"

--- a/bin/nvidia-docker-compose
+++ b/bin/nvidia-docker-compose
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 import subprocess
 import argparse
-from jinja2 import Template
-from os.path import isfile
 import yaml
 import json
 import sys
@@ -12,39 +10,51 @@ GPU_DEVICE_PATTERN = re.compile(r'/dev/nvidia\d+')
 
 # support Python 2 or 3
 if sys.version_info[0] == 3:
-  import urllib.request as request
+    import urllib.request as request
 else:
-  import urllib2 as request
+    import urllib2 as request
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-f')
+parser.add_argument('-f', '--file', metavar='INPUT_FILE', type=argparse.FileType('r'), default='docker-compose.yml',
+                    help='Specify an alternate input compose file (default: docker-compose.yml)')
+parser.add_argument('-t', '--template', type=argparse.FileType('r'),
+                    help='Specify Jinja2 template file from which compose file will be generated. '
+                         '--template argument discards --file argument.')
+parser.add_argument('-n', '--nvidia-docker-host', metavar='HOST[:PORT]', type=str, default='localhost:3476',
+                    help='nvidia-docker-plugin daemon address to connect to (default: localhost:3476)')
+parser.add_argument('-o', '--output', metavar='OUTPUT_FILE', type=argparse.FileType('w'),
+                    default='nvidia-docker-compose.yml',
+                    help='Specify an alternate output compose file (default: nvidia-docker-compose.yml)')
+parser.add_argument('-G', '--generate', action='store_true',
+                    help='Generate output compose file and exit, do not run docker-compose')
 
-(v, extras) = parser.parse_known_args()
+(args, extras) = parser.parse_known_args()
 
-resp = request.urlopen('http://localhost:3476/docker/cli/json').read().decode()
+resp = request.urlopen('http://{0}/docker/cli/json'.format(args.nvidia_docker_host)).read().decode()
 cuda_config = json.loads(resp)
 
 gpu_devices = []
 support_devices = []
+
 for dev in cuda_config['Devices']:
     if GPU_DEVICE_PATTERN.match(dev):
         gpu_devices.append(dev)
     else:
         support_devices.append(dev)
+
 gpu_devices.sort()
 n_gpu = len(gpu_devices)
 volume = cuda_config['Volumes'][0].split(':')[0]
 
-dc_file = v.f or 'docker-compose.yml'
-jinja_file = dc_file + '.jinja'
-
-if isfile(jinja_file):
-    with open(jinja_file, 'r') as f:
-        content = Template(f.read()).render(N_GPU=n_gpu, GPU_DEVICES=gpu_devices)
-        config = yaml.load(content)
+if args.template is not None:
+    from jinja2 import Template
+    content = Template(args.template.read()).render(N_GPU=n_gpu, GPU_DEVICES=gpu_devices)
+    config = yaml.load(content)
 else:
-    with open(dc_file, 'r') as f:
-        config = yaml.load(f)
+    config = yaml.load(args.file)
+
+if config is None:
+    raise RuntimeError('Compose file is empty')
 
 volumes = config.setdefault('volumes', {})
 volumes[volume] = {'external': True}
@@ -56,13 +66,10 @@ for service, sconf in config['services'].items():
         devices.extend(gpu_devices)
     devices.extend(support_devices)
 
-with open('nvidia-docker-compose.yml', 'w') as f:
-    yaml.safe_dump(config, f, default_flow_style=False)
+yaml.safe_dump(config, args.output, default_flow_style=False)
 
-command = ['docker-compose','-f', 'nvidia-docker-compose.yml'] + extras
-
-try:
-    subprocess.call(command)
-except:
-    print('Terminating')
-
+if not args.generate:
+    try:
+        subprocess.call(['docker-compose', '-f', args.output.name] + extras)
+    except:
+        print('Terminating')


### PR DESCRIPTION
Hi Edgar,

Thanks for the good work. I use nvidia-docker-compose to be able to use PyCharm Docker integration with GPU-enabled containers.

My use case is different than yours so I needed couple of new optional arguments. I added them to my fork. I think they may be useful to others as well. New arguments don't change previous behavior except automatically using Jinja file, and I think it shouldn't behave like that anyway ([Zen of Python](https://www.python.org/dev/peps/pep-0020/), explicit is better than implicit).

With the addition of new arguments, the CLI looks like this:

```
usage: nvidia-docker-compose [-h] [-f INPUT_FILE] [-t TEMPLATE]
                             [-n HOST[:PORT]] [-o OUTPUT_FILE] [-G]

optional arguments:
  -h, --help            show this help message and exit
  -f INPUT_FILE, --file INPUT_FILE
                        Specify an alternate input compose file (default:
                        docker-compose.yml)
  -t TEMPLATE, --template TEMPLATE
                        Specify Jinja2 template file from which compose file
                        will be generated. --template argument discards --file
                        argument.
  -n HOST[:PORT], --nvidia-docker-host HOST[:PORT]
                        nvidia-docker-plugin daemon address to connect to
                        (default: localhost:3476)
  -o OUTPUT_FILE, --output OUTPUT_FILE
                        Specify an alternate output compose file (default:
                        nvidia-docker-compose.yml)
  -G, --generate        Generate output compose file and exit, do not run
                        docker-compose

```